### PR TITLE
PIM-3719 - Nomad 1.6 - "nomad operator keygen" command doesn't exist …

### DIFF
--- a/tasks/get_gossip_key.yml
+++ b/tasks/get_gossip_key.yml
@@ -37,8 +37,33 @@
 
       # Generate new key if none was found
     - block:
+        - name: Get version of the installed nomad
+          ansible.builtin.shell:
+            cmd: nomad version | awk '{print $2}' | cut -c 2- | head -n 1
+          register: nomad_version_result
+            - set_fact:
+                nomad_version: "{{ nomad_version_result.stdout }}"
+                nomad_old_version: "1.4.1"
+
+            - debug:
+                msg: "Current nomand version {{ nomad_version }} is newer than {{ nomad_old_version }}"
+              when: nomad_version is version(nomad_old_version, '>')
+
+            - name: Determine is_new_version
+              set_fact:
+                is_new_version: "{{ nomad_version is version(nomad_old_version, '>') | bool }}"
+
+            - name: Set command based on is_new_version
+              set_fact:
+                command: "{{ 'nomad operator gossip keyring generate' if is_new_version else 'nomad operator keygen' }}"
+
+            - name: Debug is_new_version and command
+              debug:
+                msg:
+                  - "is_new_version: {{ is_new_version }}"
+                  - "command: {{ command }}"
         - name: Generate gossip encryption key
-          shell: "nomad operator keygen"
+          shell: "{{command}}"
           register: nomad_keygen
 
         - name: Write key locally to share with other nodes
@@ -50,7 +75,7 @@
           vars:
             ansible_become: false
           delegate_to: localhost
-      no_log: true
+      no_log: false
       run_once: true
       when:
       - lookup('first_found', dict(files=['/tmp/nomad_raw.key'], skip=true)) | ternary(false, true)


### PR DESCRIPTION
Add support for keygen on nomad higher than 1.4.1 - nomad operator keygen was deprecated and later on removed.

See - [nomad operator keygen](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific#deprecated-gossip-keyring-commands-removed)